### PR TITLE
Make transitive dependency classpath order deterministic

### DIFF
--- a/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
+++ b/ui/org.eclipse.pde.core/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainer.java
@@ -97,6 +97,15 @@ class RequiredPluginsClasspathContainer {
 	private static final Comparator<BundleDescription> BUNDLE_VERSION = Comparator
 			.comparing(BundleDescription::getVersion);
 
+	/**
+	 * Order for transitive dependency classpath entries: symbolic name first,
+	 * higher version first as tiebreaker so the classpath is deterministic
+	 * when two bundles share a symbolic name (e.g. two versions of
+	 * {@code jakarta.annotation-api} coexist in the target).
+	 */
+	static final Comparator<BundleDescription> SYMBOLIC_NAME_THEN_HIGHER_VERSION = Comparator
+			.comparing(BundleDescription::getSymbolicName).thenComparing(BUNDLE_VERSION.reversed());
+
 	private final IPluginModelBase fModel;
 	private final IBuild fBuild;
 
@@ -636,7 +645,8 @@ class RequiredPluginsClasspathContainer {
 		var closure = DependencyManager.findRequirementsClosure(roots, INCLUDE_OPTIONAL_DEPENDENCIES);
 		String systemBundleBSN = TargetPlatformHelper.getPDEState().getSystemBundle();
 		return closure.stream().filter(b -> !b.getSymbolicName().equals(systemBundleBSN))
-				.sorted(Comparator.comparing(BundleDescription::getSymbolicName)).toList();
+				.sorted(SYMBOLIC_NAME_THEN_HIGHER_VERSION)
+				.toList();
 	}
 
 	private void addSecondaryDependencies(BundleDescription desc, Set<BundleDescription> added,

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainerComparatorTest.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/internal/core/RequiredPluginsClasspathContainerComparatorTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.pde.internal.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.junit.Test;
+import org.osgi.framework.Version;
+
+/**
+ * Verifies that the transitive-dependency sort in
+ * {@link RequiredPluginsClasspathContainer} is deterministic when multiple
+ * bundles share a symbolic name. Without the version tiebreaker, the
+ * stable-sort source order — which comes from a {@code HashSet} iteration —
+ * leaks through and causes classpath containers to flip between IDE restarts
+ * (e.g. {@code jakarta.annotation-api_1.3.5} vs {@code _2.1.1}).
+ */
+public class RequiredPluginsClasspathContainerComparatorTest {
+
+	@Test
+	public void higherVersionFirstForSameSymbolicName() {
+		BundleDescription low = mockBundle("jakarta.annotation-api", "1.3.5");
+		BundleDescription high = mockBundle("jakarta.annotation-api", "2.1.1");
+
+		// Source list in ascending version order. Stream.sorted is stable, so
+		// a comparator that only compares symbolic names would preserve this
+		// order — that is the bug.
+		List<BundleDescription> sortedAscendingInput = List.of(low, high).stream()
+				.sorted(RequiredPluginsClasspathContainer.SYMBOLIC_NAME_THEN_HIGHER_VERSION)
+				.toList();
+		assertThat(sortedAscendingInput).containsExactly(high, low);
+
+		// Source list in descending version order — result must be identical.
+		List<BundleDescription> sortedDescendingInput = List.of(high, low).stream()
+				.sorted(RequiredPluginsClasspathContainer.SYMBOLIC_NAME_THEN_HIGHER_VERSION)
+				.toList();
+		assertThat(sortedDescendingInput).containsExactly(high, low);
+	}
+
+	@Test
+	public void differentSymbolicNamesSortedAlphabetically() {
+		BundleDescription a = mockBundle("bundle.a", "1.0.0");
+		BundleDescription b = mockBundle("bundle.b", "1.0.0");
+
+		assertThat(List.of(b, a).stream().sorted(RequiredPluginsClasspathContainer.SYMBOLIC_NAME_THEN_HIGHER_VERSION)
+				.toList()).containsExactly(a, b);
+	}
+
+	private static BundleDescription mockBundle(String symbolicName, String version) {
+		BundleDescription bd = mock(BundleDescription.class);
+		when(bd.getSymbolicName()).thenReturn(symbolicName);
+		when(bd.getVersion()).thenReturn(Version.parseVersion(version));
+		return bd;
+	}
+}

--- a/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
+++ b/ui/org.eclipse.pde.ui.tests/src/org/eclipse/pde/ui/tests/AllPDETests.java
@@ -17,6 +17,7 @@ import org.eclipse.pde.core.tests.internal.AllPDECoreTests;
 import org.eclipse.pde.core.tests.internal.classpath.ClasspathResolutionTest;
 import org.eclipse.pde.core.tests.internal.core.builders.BundleErrorReporterTest;
 import org.eclipse.pde.core.tests.internal.util.PDESchemaHelperTest;
+import org.eclipse.pde.internal.core.RequiredPluginsClasspathContainerComparatorTest;
 import org.eclipse.pde.ui.tests.build.properties.AllValidatorTests;
 import org.eclipse.pde.ui.tests.classpathcontributor.ClasspathContributorTest;
 import org.eclipse.pde.ui.tests.classpathresolver.ClasspathResolverTest;
@@ -63,6 +64,7 @@ import org.junit.platform.suite.api.Suite;
 	ClasspathContributorTest.class, //
 	DynamicPluginProjectReferencesTest.class, //
 	ClasspathResolutionTest.class, //
+	RequiredPluginsClasspathContainerComparatorTest.class, //
 	BundleErrorReporterTest.class, //
 	AllPDECoreTests.class, //
 	ProjectSmartImportTest.class, //


### PR DESCRIPTION
When two bundles share a symbolic name in the target platform (e.g. both `jakarta.annotation-api` 1.3.5 and 2.1.1 shipped by the SDK side by side), the sort used to emit classpath entries only compared symbolic names. `Stream.sorted` is stable, so the source order — coming from a `HashSet` iteration that varies between JVM runs — leaked into the classpath, which made the "Updating plug-in dependencies" job rewrite Plug-in Dependencies containers on every IDE restart.

Adding a `HIGHER_VERSION_FIRST` tiebreaker makes the order stable across restarts and matches the preference PDE's resolver selection policy already uses. After this, restarting twice against the same target reports `updated 0 projects` instead of dozens.

Includes a Mockito-based unit test that exercises the comparator with two bundles sharing a symbolic name in ascending and descending source order and asserts the higher-version-first result is independent of input order.