### PR TITLE
Migrate org.eclipse.e4.tools.test and org.eclipse.pde.ui.templates.tests to JUnit 5

### DIFF
--- a/e4tools/tests/org.eclipse.e4.tools.test/META-INF/MANIFEST.MF
+++ b/e4tools/tests/org.eclipse.e4.tools.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Vendor: Eclipse.org
 Bundle-Version: 1.3.100.qualifier
 Fragment-Host: org.eclipse.e4.tools;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.junit;bundle-version="4.0.0",
- org.eclipse.e4.core.contexts;bundle-version="1.3.100"
+Require-Bundle: org.eclipse.e4.core.contexts;bundle-version="1.3.100"
 Export-Package: org.eclipse.e4.tools.test;version="1.0.0";x-internal:=true
 Automatic-Module-Name: org.eclipse.e4.tools.test
+Import-Package: org.junit.jupiter.api;version="[5.0.0,6.0.0)"

--- a/e4tools/tests/org.eclipse.e4.tools.test/src/org/eclipse/e4/tools/test/FragmentExtractHelperTest.java
+++ b/e4tools/tests/org.eclipse.e4.tools.test/src/org/eclipse/e4/tools/test/FragmentExtractHelperTest.java
@@ -13,9 +13,9 @@
  ******************************************************************************/
 package org.eclipse.e4.tools.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,8 +45,8 @@ import org.eclipse.e4.ui.model.fragment.MStringModelFragment;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jonas
@@ -69,7 +69,7 @@ public class FragmentExtractHelperTest {
 	private MPlaceholder placeholder;
 	private MPart referencedPart;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		application = MApplicationFactory.INSTANCE.createApplication();
 		application.setElementId(APPLICATIONID);

--- a/e4tools/tests/org.eclipse.e4.tools.test/src/org/eclipse/e4/tools/test/FragmentMergeHelperTest.java
+++ b/e4tools/tests/org.eclipse.e4.tools.test/src/org/eclipse/e4/tools/test/FragmentMergeHelperTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.e4.tools.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.e4.internal.tools.wizards.model.FragmentMergeHelper;
 import org.eclipse.e4.ui.model.application.MApplicationElement;
@@ -26,8 +26,8 @@ import org.eclipse.e4.ui.model.application.commands.MHandler;
 import org.eclipse.e4.ui.model.fragment.MFragmentFactory;
 import org.eclipse.e4.ui.model.fragment.MModelFragments;
 import org.eclipse.e4.ui.model.fragment.MStringModelFragment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FragmentMergeHelperTest {
 
@@ -36,7 +36,7 @@ public class FragmentMergeHelperTest {
 	private MModelFragments sourceFragments;
 	private MModelFragments targetFragments;
 
-	@Before
+	@BeforeEach
 	public void setUpFragments() {
 		sourceFragments = MFragmentFactory.INSTANCE.createModelFragments();
 		targetFragments = MFragmentFactory.INSTANCE.createModelFragments();

--- a/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
+++ b/ui/org.eclipse.pde.ui.templates.tests/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Automatic-Module-Name: org.eclipse.pde.ui.templates.tests
 Eclipse-BundleShape: dir
 Import-Package: org.eclipse.jdt.launching,
  org.eclipse.jdt.launching.environments,
- org.hamcrest,
- org.junit,
- org.junit.runner,
- org.junit.runners
+ org.junit.jupiter.api;version="[5.0.0,6.0.0)",
+ org.junit.jupiter.params;version="[5.0.0,6.0.0)",
+ org.junit.jupiter.params.provider;version="[5.0.0,6.0.0)"

--- a/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
+++ b/ui/org.eclipse.pde.ui.templates.tests/src/org/eclipse/pde/ui/templates/tests/TestPDETemplates.java
@@ -15,15 +15,17 @@
 package org.eclipse.pde.ui.templates.tests;
 
 import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -57,18 +59,11 @@ import org.eclipse.pde.ui.IPluginContentWizard;
 import org.eclipse.pde.ui.tests.util.TargetPlatformUtil;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.AfterParam;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TestPDETemplates {
 
 	private static class NewProjectCreationOperationExtension extends NewProjectCreationOperation {
@@ -84,25 +79,22 @@ public class TestPDETemplates {
 		}
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void setTargetPlatform() throws CoreException, InterruptedException {
 		TargetPlatformUtil.setRunningPlatformAsTarget();
 	}
 
-	@Parameter
-	public static WizardElement template;
+	private WizardElement template;
 
-	@Parameters(name = "{index}: {0}")
-	public static Collection<WizardElement> allTemplateWizards() {
+	static Stream<WizardElement> allTemplateWizards() {
 		return Arrays.stream(new NewPluginProjectWizard().getAvailableCodegenWizards().getChildren()) //
-				.filter(WizardElement.class::isInstance).map(WizardElement.class::cast) //
-				.collect(Collectors.toList());
+				.filter(WizardElement.class::isInstance).map(WizardElement.class::cast);
 	}
 
 	private static IProject project;
 
-	@Before
-	public void createProject() throws Exception {
+	private void setUp(WizardElement template) throws Exception {
+		this.template = template;
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
 		String id = TestPDETemplates.class.getSimpleName() + '_' + template.getID();
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject(id);
@@ -113,7 +105,7 @@ public class TestPDETemplates {
 		}
 	}
 
-	private static void createProjectWithTemplate()
+	private void createProjectWithTemplate()
 			throws CoreException, InvocationTargetException, InterruptedException {
 		PluginFieldData data = new PluginFieldData();
 		data.setId(project.getName());
@@ -160,8 +152,10 @@ public class TestPDETemplates {
 		op.execute(new NullProgressMonitor());
 	}
 
-	@Test
-	public void configureProjectAndCheckMarkers() throws CoreException {
+	@ParameterizedTest(name = "{index}: {0}")
+	@MethodSource("allTemplateWizards")
+	public void configureProjectAndCheckMarkers(WizardElement template) throws Exception {
+		setUp(template);
 		project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 		long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
 		Display current = Display.getCurrent();
@@ -208,15 +202,18 @@ public class TestPDETemplates {
 			markers = new IMarker[0];
 		}
 
-		assertEquals("Template '" + template.getLabel() + "' generates errors: "
-				+ Arrays.stream(markers).map(String::valueOf).collect(Collectors.joining(System.lineSeparator())), 0,
-				markers.length);
+		assertEquals(0, markers.length,
+				"Template '" + template.getLabel() + "' generates errors: "
+						+ Arrays.stream(markers).map(String::valueOf)
+								.collect(Collectors.joining(System.lineSeparator())));
 	}
 
-	@Test
-	public void validateProduct() throws CoreException {
+	@ParameterizedTest(name = "{index}: {0}")
+	@MethodSource("allTemplateWizards")
+	public void validateProduct(WizardElement template) throws Exception {
+		setUp(template);
 		IResource productFile = project.findMember(project.getName() + ".product");
-		Assume.assumeNotNull(productFile);
+		assumeTrue(productFile != null);
 
 		WorkspaceProductModel model = new WorkspaceProductModel((IFile) productFile, false);
 		model.load();
@@ -232,13 +229,15 @@ public class TestPDETemplates {
 					.flatMap(Arrays::stream) //
 					.map(Object::toString) //
 					.collect(toSet());
-			Assert.fail("Generated product fails validation: \n" + errors);
+			fail("Generated product fails validation: \n" + errors);
 		}
 	}
 
-	@AfterParam
-	public static void deleteProject() throws CoreException {
+	@AfterEach
+	public void deleteProject() throws CoreException {
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
-		project.delete(true, new NullProgressMonitor());
+		if (project != null && project.exists()) {
+			project.delete(true, new NullProgressMonitor());
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Migrate both test bundles from JUnit 4 to JUnit 5 (Jupiter).

### org.eclipse.e4.tools.test (2 test files, 24 tests)
- Replace `@Before` → `@BeforeEach`, `org.junit.Assert` → `org.junit.jupiter.api.Assertions`, `org.junit.Test` → `org.junit.jupiter.api.Test`
- Update MANIFEST.MF: replace `Require-Bundle: org.junit` with `Import-Package: org.junit.jupiter.api`

### org.eclipse.pde.ui.templates.tests (1 test file, 50 tests)
- Convert `@RunWith(Parameterized.class)` to `@ParameterizedTest` + `@MethodSource`
- Replace `@BeforeClass` → `@BeforeAll`, `@AfterParam` → `@AfterEach`
- Replace `Assert`/`Assume` with Jupiter `Assertions`/`Assumptions`
- Fix `assertEquals` message argument order (message last in JUnit 5)
- Update MANIFEST.MF Import-Package to Jupiter packages

### Verification
Both bundles compile and all tests pass:
- `org.eclipse.e4.tools.test`: 24 tests, 0 failures
- `org.eclipse.pde.ui.templates.tests`: 50 tests, 0 failures, 24 skipped (expected — templates without .product files)